### PR TITLE
fix: free agent job failure and add date/time format validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,6 @@ poetry.lock
 docs/_build/
 docs/_static/
 docs/_templates/
+
+# Skills
+skills/

--- a/README.md
+++ b/README.md
@@ -119,12 +119,34 @@ if __name__ == "__main__":
 
 **Required environment variables for API mode:**
 - `AGENT_IDENTIFIER` - Your agent ID from admin interface (OPTIONAL for starting the API, but REQUIRED after registration for the API to work completely)
-- `PAYMENT_API_KEY` - Your payment API key from admin interface (REQUIRED)
-- `SELLER_VKEY` - Your seller wallet verification key (REQUIRED for API mode and creating purchases)
+- `PAYMENT_API_KEY` - Your payment API key from admin interface (REQUIRED for paid agents)
+- `SELLER_VKEY` - Your seller wallet verification key (REQUIRED for paid agents)
 - `PAYMENT_SERVICE_URL` - Payment service URL (optional, defaults to production)
 - `NETWORK` - Network to use: "Preprod" or "Mainnet" (optional, defaults to "Preprod")
+- `IS_FREE_AGENT` - Set to `"true"` for free (zero-cost) agents; skips payment service entirely (optional, defaults to `"false"`)
 
 **Note:** Environment variables can be set in a `.env` file. `.env` files are automatically loaded by `masumi.run()` from the current directory.
+
+#### Free Agents (Sokosumi)
+
+For **free agents** that do not charge for services:
+
+1. **List as free on Sokosumi** – When submitting your agent via the [Sokosumi listing form](https://docs.masumi.network/documentation/how-to-guides/list-agent-on-sokosumi), mark it as free (price = 0).
+2. **Register via Registry Service** – Free agents use the Registry Service for identity/listing, not the Payment Service.
+3. **Set `IS_FREE_AGENT=true`** – The agent will bypass the payment service and execute jobs immediately when `/start_job` is called.
+
+```bash
+IS_FREE_AGENT=true
+```
+
+With this, the agent does not call the payment service, does not require `PAYMENT_API_KEY` or `SELLER_VKEY` for runtime, and jobs run as soon as they are received. The SDK generates off-chain job IDs (`FREE-*`) for tracking.
+
+**Free agent works via Swagger but fails in Sokosumi?** Check:
+
+1. **`IS_FREE_AGENT=true` in deployment** – When deployed (Docker, Kodosumi, etc.), ensure the env var is set. Local `.env` works for Swagger; production needs it too.
+2. **Agent URL reachable** – Sokosumi calls your agent from its backend. The URL in the registry must be publicly reachable (no localhost).
+3. **`/status` accepts `jobId`** – The pip package accepts both `?jobId=xxx` and `?job_id=xxx` for MIP-003 compatibility.
+4. **Response uses `inputHash`** – The `/start_job` response uses camelCase `inputHash` for Sokosumi compatibility.
 
 ### Option 2: Using Endpoint Abstraction (Advanced)
 

--- a/README.md
+++ b/README.md
@@ -119,11 +119,10 @@ if __name__ == "__main__":
 
 **Required environment variables for API mode:**
 - `AGENT_IDENTIFIER` - Your agent ID from admin interface (OPTIONAL for starting the API, but REQUIRED after registration for the API to work completely)
-- `PAYMENT_API_KEY` - Your payment API key from admin interface (REQUIRED for paid agents)
+- `PAYMENT_API_KEY` - Your payment API key from admin interface (REQUIRED for paid agents; also used for registry queries)
 - `SELLER_VKEY` - Your seller wallet verification key (REQUIRED for paid agents)
-- `PAYMENT_SERVICE_URL` - Payment service URL (optional, defaults to production)
+- `PAYMENT_SERVICE_URL` - Payment service URL (optional, defaults to production; also hosts the registry endpoint)
 - `NETWORK` - Network to use: "Preprod" or "Mainnet" (optional, defaults to "Preprod")
-- `IS_FREE_AGENT` - Set to `"true"` for free (zero-cost) agents; skips payment service entirely (optional, defaults to `"false"`)
 
 **Note:** Environment variables can be set in a `.env` file. `.env` files are automatically loaded by `masumi.run()` from the current directory.
 
@@ -131,19 +130,18 @@ if __name__ == "__main__":
 
 For **free agents** that do not charge for services:
 
-1. **List as free on Sokosumi** – When submitting your agent via the [Sokosumi listing form](https://docs.masumi.network/documentation/how-to-guides/list-agent-on-sokosumi), mark it as free (price = 0).
-2. **Register via Registry Service** – Free agents use the Registry Service for identity/listing, not the Payment Service.
-3. **Set `IS_FREE_AGENT=true`** – The agent will bypass the payment service and execute jobs immediately when `/start_job` is called.
+1. **Register as free in the registry** – When registering your agent, mark it as free in the registry. The agent's free/paid status is stored in the registry and queried at runtime.
+2. **List as free on Sokosumi** – When submitting your agent via the [Sokosumi listing form](https://docs.masumi.network/documentation/how-to-guides/list-agent-on-sokosumi), mark it as free (price = 0).
 
-```bash
-IS_FREE_AGENT=true
-```
-
-With this, the agent does not call the payment service, does not require `PAYMENT_API_KEY` or `SELLER_VKEY` for runtime, and jobs run as soon as they are received. The SDK generates off-chain job IDs (`FREE-*`) for tracking.
+The SDK automatically queries the registry at runtime to determine if an agent is free. Free agents:
+- Do not require `PAYMENT_API_KEY` or `SELLER_VKEY` environment variables
+- Bypass the payment service entirely
+- Execute jobs immediately when `/start_job` is called
+- Generate off-chain job IDs (`FREE-*`) for tracking
 
 **Free agent works via Swagger but fails in Sokosumi?** Check:
 
-1. **`IS_FREE_AGENT=true` in deployment** – When deployed (Docker, Kodosumi, etc.), ensure the env var is set. Local `.env` works for Swagger; production needs it too.
+1. **Agent marked as free in registry** – Verify your agent is registered as free in the registry (not via environment variable).
 2. **Agent URL reachable** – Sokosumi calls your agent from its backend. The URL in the registry must be publicly reachable (no localhost).
 3. **`/status` accepts `jobId`** – The pip package accepts both `?jobId=xxx` and `?job_id=xxx` for MIP-003 compatibility.
 4. **Response uses `inputHash`** – The `/start_job` response uses camelCase `inputHash` for Sokosumi compatibility.

--- a/masumi/checker.py
+++ b/masumi/checker.py
@@ -255,19 +255,19 @@ class MasumiChecker:
 
         results = []
 
-        # Free agents skip payment service; payment credentials not required
-        is_free_agent = os.getenv("IS_FREE_AGENT", "false").lower() == "true"
-        if is_free_agent:
-            results.append(CheckResult(
-                passed=True,
-                message="IS_FREE_AGENT=true: Payment service skipped (Registry Service only)",
-                level="info"
-            ))
+        # Note: Free agent status is determined by querying the registry at runtime
+        # The environment variables below are required for paid agents only
+        results.append(CheckResult(
+            passed=True,
+            message="Free agent status will be determined by registry at runtime",
+            level="info"
+        ))
 
         # Required variables with validation
-        # AGENT_IDENTIFIER is a warning (server can start without it, but needed for full functionality)
-        # PAYMENT_API_KEY and SELLER_VKEY are required for paid agents (errors)
-        required_vars = [] if is_free_agent else ["PAYMENT_API_KEY", "SELLER_VKEY"]
+        # AGENT_IDENTIFIER is required to query the registry
+        # PAYMENT_API_KEY and SELLER_VKEY may be required depending on registry status
+        # (if agent is marked as paid in registry, these are required)
+        required_vars = ["PAYMENT_API_KEY", "SELLER_VKEY"]
         missing_required = []
 
         # Check AGENT_IDENTIFIER separately (as warning)
@@ -514,8 +514,8 @@ class MasumiChecker:
                         print(f"   → {result.fix_hint}")
 
             # Show required environment variables status (always show)
-            is_free = os.getenv("IS_FREE_AGENT", "false").lower() == "true"
-            required_vars = ["AGENT_IDENTIFIER"] + ([] if is_free else ["PAYMENT_API_KEY", "SELLER_VKEY"])
+            # Note: Free agent status is determined by registry, so we show all vars
+            required_vars = ["AGENT_IDENTIFIER", "PAYMENT_API_KEY", "SELLER_VKEY"]
             required_status = []
             for var in required_vars:
                 # Find the result for this variable

--- a/masumi/checker.py
+++ b/masumi/checker.py
@@ -255,10 +255,19 @@ class MasumiChecker:
 
         results = []
 
+        # Free agents skip payment service; payment credentials not required
+        is_free_agent = os.getenv("IS_FREE_AGENT", "false").lower() == "true"
+        if is_free_agent:
+            results.append(CheckResult(
+                passed=True,
+                message="IS_FREE_AGENT=true: Payment service skipped (Registry Service only)",
+                level="info"
+            ))
+
         # Required variables with validation
         # AGENT_IDENTIFIER is a warning (server can start without it, but needed for full functionality)
-        # PAYMENT_API_KEY and SELLER_VKEY are required (errors)
-        required_vars = ["PAYMENT_API_KEY", "SELLER_VKEY"]
+        # PAYMENT_API_KEY and SELLER_VKEY are required for paid agents (errors)
+        required_vars = [] if is_free_agent else ["PAYMENT_API_KEY", "SELLER_VKEY"]
         missing_required = []
 
         # Check AGENT_IDENTIFIER separately (as warning)
@@ -372,16 +381,22 @@ class MasumiChecker:
             "https://payment.masumi.network/api/v1"
         )
 
-        # Keep /api/v1 and append /health
-        health_url = f"{payment_service_url}/health"
-
         try:
             async with aiohttp.ClientSession() as session:
+                health_url = f"{payment_service_url}/health"
                 async with session.get(health_url, timeout=aiohttp.ClientTimeout(total=5)) as response:
                     if response.status == 200:
                         return CheckResult(
                             passed=True,
                             message="Payment service reachable",
+                            level="info"
+                        )
+                    if response.status == 404:
+                        # Some deployments do not expose /health, but still serve API routes.
+                        return CheckResult(
+                            passed=True,
+                            message="Payment service reachable (health endpoint not exposed)",
+                            fix_hint=f"Health check returned 404 at {health_url}; verify API routes if requests fail.",
                             level="info"
                         )
                     else:
@@ -499,7 +514,8 @@ class MasumiChecker:
                         print(f"   → {result.fix_hint}")
 
             # Show required environment variables status (always show)
-            required_vars = ["AGENT_IDENTIFIER", "PAYMENT_API_KEY", "SELLER_VKEY"]
+            is_free = os.getenv("IS_FREE_AGENT", "false").lower() == "true"
+            required_vars = ["AGENT_IDENTIFIER"] + ([] if is_free else ["PAYMENT_API_KEY", "SELLER_VKEY"])
             required_status = []
             for var in required_vars:
                 # Find the result for this variable

--- a/masumi/cli.py
+++ b/masumi/cli.py
@@ -113,12 +113,14 @@ def run(
     # API mode - create and run FastAPI server
     # Load config from environment if not provided
     if config is None:
+        is_free_agent = os.getenv("IS_FREE_AGENT", "false").lower() == "true"
         config = Config(
             payment_service_url=os.getenv(
                 "PAYMENT_SERVICE_URL",
                 "https://payment.masumi.network/api/v1"
             ),
-            payment_api_key=os.getenv("PAYMENT_API_KEY", "")
+            payment_api_key=os.getenv("PAYMENT_API_KEY", ""),
+            free_agent=is_free_agent
         )
     
     # Load agent_identifier from environment if not provided

--- a/masumi/cli.py
+++ b/masumi/cli.py
@@ -113,14 +113,13 @@ def run(
     # API mode - create and run FastAPI server
     # Load config from environment if not provided
     if config is None:
-        is_free_agent = os.getenv("IS_FREE_AGENT", "false").lower() == "true"
         config = Config(
             payment_service_url=os.getenv(
                 "PAYMENT_SERVICE_URL",
                 "https://payment.masumi.network/api/v1"
             ),
             payment_api_key=os.getenv("PAYMENT_API_KEY", ""),
-            free_agent=is_free_agent
+            free_agent=False  # Will be determined by registry check
         )
     
     # Load agent_identifier from environment if not provided

--- a/masumi/config.py
+++ b/masumi/config.py
@@ -1,8 +1,9 @@
 class Config:
     """
     Centralized configuration for the masumi package.
-    
-    Holds configuration values for payment service, registry service, and network addresses.
+
+    Holds configuration values for payment service and network addresses.
+    The payment service URL also hosts the registry endpoint (/registry/{agent-identifier}).
     For free agents (free_agent=True), payment credentials are optional.
     """
 

--- a/masumi/config.py
+++ b/masumi/config.py
@@ -3,18 +3,21 @@ class Config:
     Centralized configuration for the masumi package.
     
     Holds configuration values for payment service, registry service, and network addresses.
+    For free agents (free_agent=True), payment credentials are optional.
     """
 
-    def __init__(self, payment_service_url: str, payment_api_key: str,
+    def __init__(self, payment_service_url: str = None, payment_api_key: str = None,
                  registry_service_url: str = None, registry_api_key: str = None,
                  preprod_address: str = None,
-                 mainnet_address: str = None):
-        self.payment_service_url = payment_service_url
-        self.payment_api_key = payment_api_key
+                 mainnet_address: str = None,
+                 free_agent: bool = False):
+        self.payment_service_url = payment_service_url or ""
+        self.payment_api_key = payment_api_key or ""
         self.registry_service_url = registry_service_url
         self.registry_api_key = registry_api_key
         self.preprod_address = preprod_address
         self.mainnet_address = mainnet_address
+        self.free_agent = free_agent
         self._validate()
 
     def _validate(self):
@@ -22,15 +25,16 @@ class Config:
         Validate that all required configuration parameters are set.
         Raises ValueError if any required parameter is missing.
         
+        For free agents, payment credentials are optional.
         For detailed diagnostics, use: masumi check
         """
+        if self.free_agent:
+            return  # Free agents skip payment service; no validation needed
         missing_configs = []
-        
         if not self.payment_service_url:
             missing_configs.append("PAYMENT_SERVICE_URL")
         if not self.payment_api_key:
             missing_configs.append("PAYMENT_API_KEY")
-        
         if missing_configs:
             error_msg = f"Missing required configuration parameters: {', '.join(missing_configs)}"
             error_msg += "\n\nRun 'masumi check' for detailed diagnostics and setup instructions."

--- a/masumi/helper_functions.py
+++ b/masumi/helper_functions.py
@@ -5,6 +5,8 @@ import logging as logger
 import logging
 import sys
 import os
+import aiohttp
+from typing import Optional
 
 
 class ColoredFormatter(logging.Formatter):
@@ -164,3 +166,147 @@ def create_masumi_output_hash(output_string: str, identifier_from_purchaser: str
     result_hash = _create_hash_from_payload(escaped_output, identifier_from_purchaser)
     logger.info(f"Generated Output Hash: {result_hash}")
     return result_hash
+
+
+async def check_free_agent_from_registry(
+    agent_identifier: str,
+    payment_service_url: Optional[str] = None,
+    payment_api_key: Optional[str] = None,
+    network: str = "Preprod"
+) -> bool:
+    """
+    Query the registry to check if an agent is marked as free.
+
+    Args:
+        agent_identifier: The agent identifier to check
+        payment_service_url: URL of the payment service (same service hosts registry endpoint)
+        payment_api_key: API key for the service
+        network: The Cardano network (Preprod or Mainnet)
+
+    Returns:
+        bool: True if the agent is marked as free, False otherwise
+
+    Raises:
+        Exception: If registry query fails
+    """
+    # Use default payment service URL if not provided
+    if not payment_service_url:
+        payment_service_url = os.getenv(
+            "PAYMENT_SERVICE_URL",
+            "https://payment.masumi.network/api/v1"
+        )
+
+    # Load API key from env if not provided
+    if not payment_api_key:
+        payment_api_key = os.getenv("PAYMENT_API_KEY", "")
+
+    if not agent_identifier or agent_identifier == "unregistered-agent":
+        # If agent is not registered, assume not free (default behavior)
+        logging.warning(
+            "Agent identifier not set or unregistered. Assuming non-free agent. "
+            "Set AGENT_IDENTIFIER environment variable or register your agent."
+        )
+        return False
+
+    # Check if API key is available
+    if not payment_api_key:
+        logging.error(
+            "PAYMENT_API_KEY is not set. Cannot query registry without authentication. "
+            "Assuming non-free agent."
+        )
+        return False
+
+    try:
+        # Build headers - try both token and x-api-key for compatibility
+        # Payment endpoints use "token", registry might use "x-api-key"
+        headers = {
+            "Content-Type": "application/json",
+            "token": payment_api_key,
+            "x-api-key": payment_api_key
+        }
+        logging.info(f"Registry auth: Using API key {payment_api_key[:8] if payment_api_key else 'NONE'}... (masked)")
+
+        # Registry endpoint is under /api/v1/ on the payment service
+        # Use the payment_service_url directly (it already includes /api/v1)
+        base_url = payment_service_url.rstrip('/')
+
+        # Query registry endpoint: /registry/agent-identifier with query params
+        # NOT /registry/{id} - the path is literally "agent-identifier"
+        url = f"{base_url}/registry/agent-identifier"
+        params = {
+            "agentIdentifier": agent_identifier,
+            "network": network
+        }
+        logging.info(f"Querying registry at: {url}?agentIdentifier={agent_identifier[:8]}...&network={network}")
+
+        async with aiohttp.ClientSession() as session:
+            async with session.get(url, headers=headers, params=params, timeout=aiohttp.ClientTimeout(total=10)) as response:
+                response_text = await response.text()
+
+                if response.status == 404:
+                    # Agent not found in registry - assume not free
+                    logging.warning(
+                        f"Agent {agent_identifier[:8]}... not found in registry (404). "
+                        f"Response: {response_text}. "
+                        "Assuming non-free agent. Register your agent first."
+                    )
+                    return False
+
+                if response.status != 200:
+                    logging.error(
+                        f"Registry query failed with status {response.status}. "
+                        f"Response: {response_text}. "
+                        "Assuming non-free agent."
+                    )
+                    return False
+
+                # Parse response
+                try:
+                    data = await response.json()
+                except Exception as e:
+                    logging.error(f"Failed to parse registry response as JSON: {response_text}. Error: {e}")
+                    return False
+
+                logging.info(f"Registry response for agent {agent_identifier[:8]}...: {data}")
+
+                # Check if agent is marked as free
+                agent_data = data.get("data", {})
+                metadata = agent_data.get("Metadata", {})
+                agent_pricing = metadata.get("AgentPricing", {})
+
+                # Check 1: pricingType field (most common for free agents)
+                pricing_type = agent_pricing.get("pricingType", "")
+                is_free = pricing_type.lower() == "free"
+
+                # Check 2: If pricingType is not "Free", check Pricing array for amount "0"
+                if not is_free:
+                    pricing_list = agent_pricing.get("Pricing", [])
+                    if pricing_list:
+                        is_free = all(
+                            str(price.get("amount", "1")) == "0"
+                            for price in pricing_list
+                        )
+
+                # Check 3: Explicit isFree field as fallback
+                if not is_free:
+                    is_free = agent_data.get("isFree", False) or agent_data.get("is_free", False)
+
+                logging.info(
+                    f"Agent {agent_identifier[:8]}... registry check: "
+                    f"{'FREE agent' if is_free else 'PAID agent'}"
+                )
+
+                return is_free
+
+    except aiohttp.ClientError as e:
+        logging.error(
+            f"Network error querying registry for agent {agent_identifier[:8]}...: {e}. "
+            "Assuming non-free agent."
+        )
+        return False
+    except Exception as e:
+        logging.error(
+            f"Unexpected error querying registry for agent {agent_identifier[:8]}...: {e}. "
+            "Assuming non-free agent."
+        )
+        return False

--- a/masumi/job_manager.py
+++ b/masumi/job_manager.py
@@ -180,15 +180,18 @@ class JobManager:
         
         if payment and job and job.get("payment_id"):
             payment_id = job.get("payment_id")
-            logger.info(f"Submitting result on-chain for job {job_id} (payment ID: {payment_id})")
-            logger.info(f"Result length: {len(result)} characters")
-            try:
-                # This will raise if submission fails, which is intended
-                await payment.complete_payment(payment_id, result)
-                logger.info(f"Result submitted on-chain successfully for job {job_id}")
-            except Exception as e:
-                logger.error(f"On-chain result submission FAILED for job {job_id}: {str(e)}")
-                raise
+            # Free agent jobs use FREE-* identifiers; skip payment service (no on-chain submission)
+            if payment_id.startswith("FREE-"):
+                logger.info(f"Free agent job {job_id} (payment ID: {payment_id}) — skipping on-chain submission")
+            else:
+                logger.info(f"Submitting result on-chain for job {job_id} (payment ID: {payment_id})")
+                logger.info(f"Result length: {len(result)} characters")
+                try:
+                    await payment.complete_payment(payment_id, result)
+                    logger.info(f"Result submitted on-chain successfully for job {job_id}")
+                except Exception as e:
+                    logger.error(f"On-chain result submission FAILED for job {job_id}: {str(e)}")
+                    raise
         else:
             reason = []
             if not payment: reason.append("payment instance missing")

--- a/masumi/models.py
+++ b/masumi/models.py
@@ -4,7 +4,7 @@ Pydantic models for MIP-003 request and response structures.
 
 from enum import Enum
 from typing import List, Optional, Dict, Any
-from pydantic import BaseModel, Field
+from pydantic import AliasChoices, BaseModel, ConfigDict, Field
 
 
 class JobStatus(str, Enum):
@@ -43,12 +43,27 @@ class PaymentNextAction(str, Enum):
     AUTHORIZE_REFUND_INITIATED = "AuthorizeRefundInitiated"
 
 
+def _default_identifier() -> str:
+    """Default identifier when caller (e.g. Sokosumi) omits it."""
+    import uuid
+    return f"sokosumi-{uuid.uuid4().hex[:16]}"
+
+
 class StartJobRequest(BaseModel):
     """Request model for /start_job endpoint"""
-    identifier_from_purchaser: str = Field(..., description="Purchaser-defined identifier")
-    input_data: Optional[Dict[str, Any]] = Field(None, description="Input data matching the input schema")
+    identifier_from_purchaser: str = Field(
+        default_factory=_default_identifier,
+        alias="identifierFromPurchaser",
+        description="Purchaser-defined identifier (optional; generated if omitted)",
+    )
+    input_data: Optional[Dict[str, Any]] = Field(
+        None,
+        validation_alias=AliasChoices("inputData", "input_data", "input"),
+        description="Input data matching the input schema",
+    )
     
     class Config:
+        populate_by_name = True
         json_schema_extra = {
             "example": {
                 "identifier_from_purchaser": "resume-job-123",
@@ -70,11 +85,12 @@ class StartJobResponse(BaseModel):
     agentIdentifier: str = Field(..., description="Agent Identifier")
     sellerVKey: str = Field(..., description="Wallet Public Key")
     identifierFromPurchaser: str = Field(..., description="Echoes back the identifier from purchaser")
-    input_hash: str = Field(..., alias="input_hash", description="Hash of the input data")
+    input_hash: str = Field(..., alias="inputHash", description="Hash of the input data")
     
-    class Config:
-        populate_by_name = True
-        json_schema_extra = {
+    model_config = ConfigDict(
+        populate_by_name=True,
+        serialize_by_alias=True,  # MIP-003/Sokosumi expect camelCase (inputHash)
+        json_schema_extra={
             "example": {
                 "id": "18d66eed-6af5-4589-b53a-d2e78af657b6",
                 "blockchainIdentifier": "block_789def",
@@ -85,9 +101,10 @@ class StartJobResponse(BaseModel):
                 "agentIdentifier": "resume-wizard-v1",
                 "sellerVKey": "addr1qxlkjl23k4jlksdjfl234jlksdf",
                 "identifierFromPurchaser": "resume-job-123",
-                "input_hash": "a87ff679a2f3e71d9181a67b7542122c"
+                "inputHash": "a87ff679a2f3e71d9181a67b7542122c"
             }
-        }
+        },
+    )
 
 
 class StatusResponse(BaseModel):
@@ -229,5 +246,3 @@ class DemoResponse(BaseModel):
                 }
             }
         }
-
-

--- a/masumi/payment.py
+++ b/masumi/payment.py
@@ -3,6 +3,7 @@ from datetime import datetime, timezone, timedelta
 import asyncio
 import logging
 import json
+from decimal import Decimal, InvalidOperation
 from typing import List, Optional, Dict, Any, Set
 import aiohttp
 from .config import Config
@@ -68,6 +69,8 @@ class Payment:
         self.payment_type = "Web3CardanoV1"
         self.payment_ids: Set[str] = set()
         self._callback_triggered_ids: Set[str] = set()
+        self._logged_error_ids: Set[str] = set()  # Track payments with logged errors (separate from callbacks)
+        self._logged_warning_ids: Set[str] = set()  # Track payments with logged missing-fields warning (once per payment)
         self._callback_tasks: Set[asyncio.Task] = set()  # Track callback tasks to prevent memory leaks
         self.identifier_from_purchaser = identifier_from_purchaser
         self._status_check_task: Optional[asyncio.Task] = None
@@ -86,6 +89,89 @@ class Payment:
         logger.debug(f"Input hash: {self.input_hash}")
         #logger.debug(f"Payment amounts configured: {[f'{a.amount} {a.unit}' for a in amounts]}")
         logger.debug(f"Using purchaser identifier: {self.identifier_from_purchaser}")
+
+    @staticmethod
+    def _is_zero_value(value: Any) -> bool:
+        """Return True when the supplied value represents numeric zero."""
+        if value is None or isinstance(value, bool):
+            return False
+
+        if isinstance(value, (int, float, Decimal)):
+            return value == 0
+
+        if isinstance(value, str):
+            normalized = value.strip()
+            if not normalized:
+                return False
+            try:
+                return Decimal(normalized) == 0
+            except InvalidOperation:
+                return False
+
+        return False
+
+    @classmethod
+    def _is_free_payment(cls, payment: Dict[str, Any]) -> bool:
+        """
+        Detect whether the payment payload represents a zero-cost agent.
+
+        The payment service may return zero values as numbers or strings, and
+        may surface them as `price`, `amount`, or per-entry `amounts`.
+        """
+        if "price" in payment and cls._is_zero_value(payment.get("price")):
+            return True
+
+        if "amount" in payment and cls._is_zero_value(payment.get("amount")):
+            return True
+
+        amounts = payment.get("amounts")
+        if isinstance(amounts, list) and amounts:
+            return all(
+                isinstance(amount_entry, dict)
+                and cls._is_zero_value(amount_entry.get("amount"))
+                for amount_entry in amounts
+            )
+
+        return False
+
+    async def create_free_agent_mock_payment(self) -> Dict[str, Any]:
+        """
+        Create a mock payment response for free agents without hitting the payment service.
+        Free agents don't need blockchain interaction or on-chain fees.
+        """
+        import uuid
+
+        # Generate a unique ID for tracking (not blockchain)
+        free_payment_id = f"FREE-{uuid.uuid4().hex[:24]}"
+
+        # Set mock timestamps (not used for free agents but required by response model)
+        now = datetime.now(timezone.utc)
+        mock_time = int(now.timestamp())
+
+        logger.info(f"Creating mock payment for free agent: {free_payment_id}")
+
+        return {
+            "status": "success",
+            "data": {
+                "blockchainIdentifier": free_payment_id,
+                "payByTime": mock_time,
+                "submitResultTime": mock_time + 86400,  # +24 hours
+                "unlockTime": mock_time,
+                "externalDisputeUnlockTime": mock_time,
+                "agentIdentifier": self.agent_identifier,
+                "sellerVKey": "",  # No wallet needed for free agents
+                "identifierFromPurchaser": self.identifier_from_purchaser,
+                "inputHash": self.input_hash or "",
+                "isFreeAgent": True,  # Flag to indicate free agent
+                "onChainState": "FREE_AGENT"  # Special state
+            },
+            "time_values": {
+                "payByTime": mock_time,
+                "submitResultTime": mock_time + 86400,
+                "unlockTime": mock_time,
+                "externalDisputeUnlockTime": mock_time
+            }
+        }
 
     async def create_payment_request(self, metadata: Optional[str] = None) -> Dict[str, Any]:
         """
@@ -322,7 +408,9 @@ class Payment:
             callback (Callable, optional): Function to call when a payment is ready to process.
                 The callback is triggered when payment reaches either:
                 - FundsLocked state (PaymentOnChainState.FUNDS_LOCKED) for paid agents
-                - FundsOrDatumInvalid state (PaymentOnChainState.FUNDS_OR_DATUM_INVALID) for free agents
+                - FundsOrDatumInvalid state (PaymentOnChainState.FUNDS_OR_DATUM_INVALID) for free agents ONLY
+                  (validated by checking if price/amount is 0 in payment data)
+                Note: For paid agents, FundsOrDatumInvalid means an actual error and callback is NOT triggered.
                 The function will receive the full payment dict as its parameter.
                 Can be either a regular function or an async function.
                 The callback runs in a separate task to avoid blocking the monitoring loop.
@@ -414,11 +502,40 @@ class Payment:
                             
                             logger.debug(f"Payment {payment_id[:8]}...: state={on_chain_state}, action={next_action}")
 
-                            # Trigger callback when payment is ready to process
-                            # FundsLocked: Normal paid agents (payment received and locked)
-                            # FundsOrDatumInvalid: Free agents (0 cost - no funds to lock, but job should still execute)
-                            if (on_chain_state in [PaymentOnChainState.FUNDS_LOCKED.value, PaymentOnChainState.FUNDS_OR_DATUM_INVALID.value]
-                                and payment_id not in self._callback_triggered_ids):
+                            # Determine if we should trigger the callback based on on-chain state
+                            should_trigger_callback = False
+
+                            # FundsLocked: Always valid - payment received and locked (normal paid agents)
+                            if on_chain_state == PaymentOnChainState.FUNDS_LOCKED.value:
+                                should_trigger_callback = True
+
+                            # FundsOrDatumInvalid: Only valid for free agents (0 cost)
+                            # For paid agents, this state means funds/datum are genuinely invalid (wrong amount, etc.)
+                            elif on_chain_state == PaymentOnChainState.FUNDS_OR_DATUM_INVALID.value:
+                                is_free_agent = self._is_free_payment(payment)
+
+                                if is_free_agent:
+                                    logger.info(f"Payment {payment_id[:8]}... is a free agent (0 cost), accepting FundsOrDatumInvalid state")
+                                    should_trigger_callback = True
+                                else:
+                                    # Mark as logged to prevent error log spam on subsequent checks
+                                    # Use separate set from callback tracking to allow state transitions
+                                    if not any(k in payment for k in ("price", "amount", "amounts")):
+                                        if payment_id not in self._logged_warning_ids:
+                                            logger.warning(
+                                                f"Payment {payment_id[:8]}... hit FundsOrDatumInvalid but payment data "
+                                                "contains no price/amount/amounts field — cannot determine if free agent. "
+                                                "Treating as paid (not triggering callback)."
+                                            )
+                                            self._logged_warning_ids.add(payment_id)
+                                    if payment_id not in self._logged_error_ids:
+                                        logger.error(f"Payment {payment_id[:8]}... reached FundsOrDatumInvalid state but is NOT a free agent - this indicates invalid funds or datum. Not triggering callback.")
+                                        logger.error(f"Payment data: {payment}")
+                                        self._logged_error_ids.add(payment_id)
+                                    # Do not trigger callback - this is a genuine error for paid agents
+
+                            # Trigger callback if valid and not already triggered
+                            if should_trigger_callback and payment_id not in self._callback_triggered_ids:
                                 logger.info(f"Payment {payment_id[:8]}... reached {on_chain_state} state, triggering callback")
                                 self._callback_triggered_ids.add(payment_id)
                                 
@@ -449,16 +566,26 @@ class Payment:
                             # Remove from tracking when payment is actually complete
                             # This happens after the callback has processed the payment and submitted results
                             # Stop checking when result is submitted or payment reaches final withdrawal states
-                            if (on_chain_state in [
-                                PaymentOnChainState.RESULT_SUBMITTED.value
-
-                            ] or
-                                next_action == PaymentNextAction.NONE.value):
-                                
+                            # Also remove FundsOrDatumInvalid: paid agents (in _logged_error_ids) or free agents (in _callback_triggered_ids)
+                            # - both have this as a terminal state with no further transition
+                            is_complete = (
+                                on_chain_state == PaymentOnChainState.RESULT_SUBMITTED.value
+                                or next_action == PaymentNextAction.NONE.value
+                                or (
+                                    on_chain_state == PaymentOnChainState.FUNDS_OR_DATUM_INVALID.value
+                                    and (
+                                        payment_id in self._logged_error_ids
+                                        or payment_id in self._callback_triggered_ids
+                                    )
+                                )
+                            )
+                            if is_complete:
                                 logger.info(f"Payment {payment_id[:8]}... is complete, removing from tracking")
                                 payments_to_remove.append(payment_id)
                                 # Clean up tracking
                                 self._callback_triggered_ids.discard(payment_id)
+                                self._logged_error_ids.discard(payment_id)
+                                self._logged_warning_ids.discard(payment_id)
                                 payment_check_times.pop(payment_id, None)
                         
                         except Exception as e:
@@ -501,8 +628,10 @@ class Payment:
             logger.info("Stopping payment status monitoring")
             self._status_check_task.cancel()
             self._status_check_task = None
-            # Clean up callback tracking
+            # Clean up callback and error tracking
             self._callback_triggered_ids.clear()
+            self._logged_error_ids.clear()
+            self._logged_warning_ids.clear()
         
         # Cancel any pending callback tasks
         if self._callback_tasks:

--- a/masumi/payment.py
+++ b/masumi/payment.py
@@ -320,7 +320,9 @@ class Payment:
         
         Args:
             callback (Callable, optional): Function to call when a payment is ready to process.
-                The callback is triggered when payment reaches FundsLocked state (PaymentOnChainState.FUNDS_LOCKED).
+                The callback is triggered when payment reaches either:
+                - FundsLocked state (PaymentOnChainState.FUNDS_LOCKED) for paid agents
+                - FundsOrDatumInvalid state (PaymentOnChainState.FUNDS_OR_DATUM_INVALID) for free agents
                 The function will receive the full payment dict as its parameter.
                 Can be either a regular function or an async function.
                 The callback runs in a separate task to avoid blocking the monitoring loop.
@@ -411,11 +413,13 @@ class Payment:
                                 continue
                             
                             logger.debug(f"Payment {payment_id[:8]}...: state={on_chain_state}, action={next_action}")
-                            
-                            # Trigger callback ONLY when payment is ready to process (FundsLocked)
-                            # and we haven't triggered it yet
-                            if on_chain_state == PaymentOnChainState.FUNDS_LOCKED.value and payment_id not in self._callback_triggered_ids:
-                                logger.info(f"Payment {payment_id[:8]}... reached FundsLocked state, triggering callback")
+
+                            # Trigger callback when payment is ready to process
+                            # FundsLocked: Normal paid agents (payment received and locked)
+                            # FundsOrDatumInvalid: Free agents (0 cost - no funds to lock, but job should still execute)
+                            if (on_chain_state in [PaymentOnChainState.FUNDS_LOCKED.value, PaymentOnChainState.FUNDS_OR_DATUM_INVALID.value]
+                                and payment_id not in self._callback_triggered_ids):
+                                logger.info(f"Payment {payment_id[:8]}... reached {on_chain_state} state, triggering callback")
                                 self._callback_triggered_ids.add(payment_id)
                                 
                                 # Call the callback function if provided

--- a/masumi/scaffold_templates.py
+++ b/masumi/scaffold_templates.py
@@ -100,9 +100,6 @@ def _get_env_template(database: Optional[str], additional_libs: List[str]) -> st
         "# Testing - skip blockchain payments",
         "#MOCK_PAYMENTS=false",
         "",
-        "# Free agents (Sokosumi): set to true for zero-cost agents",
-        "IS_FREE_AGENT=true",
-        "",
     ]
     
     # Database environment variables

--- a/masumi/scaffold_templates.py
+++ b/masumi/scaffold_templates.py
@@ -100,6 +100,9 @@ def _get_env_template(database: Optional[str], additional_libs: List[str]) -> st
         "# Testing - skip blockchain payments",
         "#MOCK_PAYMENTS=false",
         "",
+        "# Free agents (Sokosumi): set to true for zero-cost agents",
+        "IS_FREE_AGENT=true",
+        "",
     ]
     
     # Database environment variables

--- a/masumi/server.py
+++ b/masumi/server.py
@@ -9,6 +9,7 @@ import os
 import uuid
 from typing import Optional, Callable, Dict, Any, Awaitable, Union, Set
 from fastapi import FastAPI, HTTPException, Query, Request
+from fastapi.responses import JSONResponse
 from fastapi.exceptions import RequestValidationError
 
 from .config import Config
@@ -154,7 +155,6 @@ class MasumiAgentServer:
                 f"Request validation failed (422) for {request.url.path}: "
                 f"errors={exc.errors()}, body={body.decode('utf-8', errors='replace')[:500]}"
             )
-            from fastapi.responses import JSONResponse
             return JSONResponse(status_code=422, content={"detail": exc.errors()})
         
         # Register all endpoints

--- a/masumi/server.py
+++ b/masumi/server.py
@@ -26,7 +26,7 @@ from .models import (
 from .endpoints import AgentEndpointHandler
 from .job_manager import JobManager, JobStorage, InMemoryJobStorage
 from .validation import validate_input_data, ValidationError
-from .helper_functions import setup_logging, create_masumi_input_hash
+from .helper_functions import setup_logging, create_masumi_input_hash, check_free_agent_from_registry
 from .models import JobStatus
 from .hitl import set_job_context, clear_job_context, provide_input_to_job
 
@@ -95,16 +95,11 @@ class MasumiAgentServer:
         # Load seller_vkey from environment if not provided
         if not seller_vkey:
             seller_vkey = os.getenv("SELLER_VKEY")
-        
-        # Validate seller_vkey is provided (not required for free agents)
-        is_free_agent = getattr(config, "free_agent", False)
-        if not seller_vkey and not is_free_agent:
-            raise ValueError(
-                "seller_vkey is required. Provide it directly or set SELLER_VKEY environment variable. "
-                "Get your seller_vkey from the admin interface after registering your agent."
-            )
+
+        # Note: seller_vkey validation moved to /start_job endpoint after registry check
+        # (registry determines if agent is free; free agents don't need seller_vkey)
         if not seller_vkey:
-            seller_vkey = ""  # Free agents use empty seller vkey
+            seller_vkey = ""  # Will be validated in start_job if not a free agent
         
         self.config = config
         self.agent_identifier = agent_identifier
@@ -203,8 +198,20 @@ class MasumiAgentServer:
                         detail="Start job handler not configured"
                     )
 
-                # Check if this is a free agent (from config; env var used by CLI when creating config)
-                is_free_agent = getattr(self.config, "free_agent", False)
+                # Check if this is a free agent by querying the registry
+                is_free_agent = await check_free_agent_from_registry(
+                    agent_identifier=self.agent_identifier,
+                    payment_service_url=self.config.payment_service_url,
+                    payment_api_key=self.config.payment_api_key,
+                    network=self.network
+                )
+
+                # Validate seller_vkey for paid agents
+                if not is_free_agent and not self.seller_vkey:
+                    raise HTTPException(
+                        status_code=500,
+                        detail="seller_vkey is required for paid agents. Set SELLER_VKEY environment variable or provide it when creating the server."
+                    )
 
                 # Create payment request or mock for free agent
                 payment = Payment(

--- a/masumi/server.py
+++ b/masumi/server.py
@@ -5,9 +5,11 @@ FastAPI server framework for MIP-003 agent endpoints.
 import asyncio
 import json
 import logging
+import os
 import uuid
 from typing import Optional, Callable, Dict, Any, Awaitable, Union, Set
-from fastapi import FastAPI, HTTPException, Query
+from fastapi import FastAPI, HTTPException, Query, Request
+from fastapi.exceptions import RequestValidationError
 
 from .config import Config
 from .payment import Payment
@@ -94,12 +96,15 @@ class MasumiAgentServer:
         if not seller_vkey:
             seller_vkey = os.getenv("SELLER_VKEY")
         
-        # Validate seller_vkey is provided
-        if not seller_vkey:
+        # Validate seller_vkey is provided (not required for free agents)
+        is_free_agent = getattr(config, "free_agent", False)
+        if not seller_vkey and not is_free_agent:
             raise ValueError(
                 "seller_vkey is required. Provide it directly or set SELLER_VKEY environment variable. "
                 "Get your seller_vkey from the admin interface after registering your agent."
             )
+        if not seller_vkey:
+            seller_vkey = ""  # Free agents use empty seller vkey
         
         self.config = config
         self.agent_identifier = agent_identifier
@@ -141,6 +146,21 @@ class MasumiAgentServer:
         @self.app.on_event("shutdown")
         async def shutdown_handler():
             await self.cleanup_background_tasks()
+
+        # Log 422 validation errors for debugging (e.g. Sokosumi request format)
+        @self.app.exception_handler(RequestValidationError)
+        async def validation_exception_handler(request: Request, exc: RequestValidationError):
+            body = b""
+            try:
+                body = await request.body()
+            except Exception:
+                pass
+            logger.warning(
+                f"Request validation failed (422) for {request.url.path}: "
+                f"errors={exc.errors()}, body={body.decode('utf-8', errors='replace')[:500]}"
+            )
+            from fastapi.responses import JSONResponse
+            return JSONResponse(status_code=422, content={"detail": exc.errors()})
         
         # Register all endpoints
         self._register_endpoints()
@@ -182,8 +202,11 @@ class MasumiAgentServer:
                         status_code=500,
                         detail="Start job handler not configured"
                     )
-                
-                # Create payment request
+
+                # Check if this is a free agent (from config; env var used by CLI when creating config)
+                is_free_agent = getattr(self.config, "free_agent", False)
+
+                # Create payment request or mock for free agent
                 payment = Payment(
                     agent_identifier=self.agent_identifier,
                     config=self.config,
@@ -191,11 +214,17 @@ class MasumiAgentServer:
                     input_data=request.input_data,
                     network=self.network
                 )
-                
-                logger.info("Creating payment request...")
-                payment_request = await payment.create_payment_request()
-                blockchain_identifier = payment_request["data"]["blockchainIdentifier"]
-                payment.payment_ids.add(blockchain_identifier)
+
+                if is_free_agent:
+                    logger.info("Free agent detected - bypassing payment service")
+                    # Create mock payment response without hitting payment service
+                    payment_request = await payment.create_free_agent_mock_payment()
+                    blockchain_identifier = payment_request["data"]["blockchainIdentifier"]
+                else:
+                    logger.info("Creating payment request...")
+                    payment_request = await payment.create_payment_request()
+                    blockchain_identifier = payment_request["data"]["blockchainIdentifier"]
+                    payment.payment_ids.add(blockchain_identifier)
                 
                 # Get seller vkey (use provided or from env/config)
                 seller_vkey = self.seller_vkey or payment_request["data"].get("sellerVKey", "")
@@ -214,16 +243,24 @@ class MasumiAgentServer:
                     seller_vkey=seller_vkey,
                     input_hash=payment.input_hash
                 )
-                
-                # Set up payment callback
-                # Callback receives the full payment dict (as per payment.py documentation)
-                async def payment_callback(payment: Dict[str, Any]):
-                    payment_id = payment.get("blockchainIdentifier", "")
-                    await self._handle_payment_confirmed(job_id, payment_id)
-                
-                # Start monitoring payment
-                logger.info(f"Starting payment monitoring for job {job_id}")
-                await payment.start_status_monitoring(callback=payment_callback)
+
+                if is_free_agent:
+                    # For free agents, immediately trigger the job without waiting for payment
+                    logger.info(f"Free agent job {job_id} - executing immediately without payment")
+                    # Schedule the job execution in background; keep strong reference to prevent GC
+                    task = asyncio.create_task(self._handle_payment_confirmed(job_id, blockchain_identifier))
+                    self._background_tasks.add(task)
+                    task.add_done_callback(self._background_tasks.discard)
+                else:
+                    # Set up payment callback for paid agents
+                    # Callback receives the full payment dict (as per payment.py documentation)
+                    async def payment_callback(payment: Dict[str, Any]):
+                        payment_id = payment.get("blockchainIdentifier", "")
+                        await self._handle_payment_confirmed(job_id, payment_id)
+
+                    # Start monitoring payment
+                    logger.info(f"Starting payment monitoring for job {job_id}")
+                    await payment.start_status_monitoring(callback=payment_callback)
                 
                 # Return response
                 return StartJobResponse(
@@ -255,19 +292,28 @@ class MasumiAgentServer:
                 )
         
         @self.app.get("/status", response_model=StatusResponse)
-        async def get_status(job_id: str = Query(..., description="The ID of the job to check")):
+        async def get_status(
+            jobId: Optional[str] = Query(None, alias="jobId", description="Job ID (MIP-003)"),
+            job_id: Optional[str] = Query(None, alias="job_id", description="Job ID (legacy)"),
+        ):
             """MIP-003: /status - Retrieves the current status of a specific job"""
+            job_id_resolved = jobId or job_id
+            if not job_id_resolved:
+                raise HTTPException(
+                    status_code=422,
+                    detail="Missing required query parameter: jobId or job_id",
+                )
             # Use custom handler if provided
             custom_handler = self.handler.get_status_handler()
             if custom_handler:
                 try:
-                    return await custom_handler(job_id)
+                    return await custom_handler(job_id_resolved)
                 except Exception as e:
                     logger.error(f"Error in custom status handler: {e}", exc_info=True)
                     raise HTTPException(status_code=500, detail=str(e))
             
             # Default implementation
-            job = await self.job_manager.get_job(job_id)
+            job = await self.job_manager.get_job(job_id_resolved)
             if not job:
                 raise HTTPException(status_code=404, detail="Job not found")
             
@@ -474,11 +520,14 @@ class MasumiAgentServer:
                 await self.job_manager.cleanup_payment_instance(job_id)
                 return
             
-            # Note: We do NOT call cleanup_payment_instance(job_id) here anymore.
-            # Instead, we let the background monitoring task continue until it 
-            # sees the 'Complete' state on-chain, at which point it will 
-            # naturally stop monitoring that payment ID.
-            logger.info(f"Job {job_id} logic finished. Monitoring will continue until on-chain confirmation.")
+            # Free agents never start payment monitoring, so we must cleanup here.
+            # Paid agents: monitoring task runs until on-chain confirmation; no cleanup needed here.
+            payment_id = job.get("payment_id", "")
+            if payment_id.startswith("FREE-"):
+                await self.job_manager.cleanup_payment_instance(job_id)
+                logger.info(f"Free agent job {job_id} finished; payment instance cleaned up.")
+            else:
+                logger.info(f"Job {job_id} logic finished. Monitoring will continue until on-chain confirmation.")
             
         except Exception as e:
             logger.error(f"Fatal error in _execute_agent_job for job {job_id}: {e}", exc_info=True)

--- a/masumi/tests/test_endpoints.py
+++ b/masumi/tests/test_endpoints.py
@@ -2,13 +2,19 @@
 Tests for endpoint handlers, validation, and FastAPI integration.
 """
 
+import os
 import pytest
 import asyncio
+from unittest.mock import patch, AsyncMock
+from fastapi.testclient import TestClient
+
 from masumi.endpoints import AgentEndpointHandler
+from masumi.models import StartJobRequest
 from masumi.validation import validate_input_data, ValidationError
 from masumi.job_manager import JobManager, InMemoryJobStorage
 from masumi.config import Config
 from masumi.payment import Payment
+from masumi.server import create_masumi_app
 
 
 @pytest.fixture
@@ -359,6 +365,159 @@ def test_job_manager(mock_config):
     job = asyncio.run(manager.get_job(job_id))
     assert job["status"] == "running"
     assert job["result"] is None
+
+
+def test_start_job_request_accepts_camel_case():
+    """StartJobRequest should accept the admin/UI camelCase payload shape."""
+    request = StartJobRequest.model_validate(
+        {
+            "identifierFromPurchaser": "buyer-123",
+            "inputData": {"text": "hello"},
+        }
+    )
+
+    assert request.identifier_from_purchaser == "buyer-123"
+    assert request.input_data == {"text": "hello"}
+
+
+def test_start_job_request_accepts_snake_case():
+    """StartJobRequest should remain backwards-compatible with snake_case payloads."""
+    request = StartJobRequest.model_validate(
+        {
+            "identifier_from_purchaser": "buyer-123",
+            "input_data": {"text": "hello"},
+        }
+    )
+
+    assert request.identifier_from_purchaser == "buyer-123"
+    assert request.input_data == {"text": "hello"}
+
+
+@pytest.mark.parametrize(
+    ("payment_payload", "expected"),
+    [
+        ({"price": 0}, True),
+        ({"price": "0"}, True),
+        ({"price": "0.0"}, True),
+        ({"amount": 0}, True),
+        ({"amount": "0"}, True),
+        ({"amounts": [{"amount": 0}, {"amount": "0"}]}, True),
+        ({"price": 1}, False),
+        ({"amount": "1"}, False),
+        ({"amounts": [{"amount": 0}, {"amount": 1}]}, False),
+        ({}, False),
+    ],
+)
+def test_payment_free_agent_detection(payment_payload, expected):
+    """Zero-cost payments should be detected across numeric and string payload shapes."""
+    assert Payment._is_free_payment(payment_payload) is expected
+
+
+@pytest.mark.asyncio
+async def test_create_free_agent_mock_payment_returns_off_chain_shape(mock_config):
+    """Free agent mock payment must be off-chain: FREE- id, isFreeAgent, no payment service call."""
+    payment = Payment(
+        agent_identifier="test-agent",
+        config=mock_config,
+        network="Preprod",
+        identifier_from_purchaser="purchaser-1",
+        input_data={"text": "hello"},
+    )
+    result = await payment.create_free_agent_mock_payment()
+
+    assert result["status"] == "success"
+    data = result["data"]
+    assert data["blockchainIdentifier"].startswith("FREE-")
+    assert data["isFreeAgent"] is True
+    assert data["onChainState"] == "FREE_AGENT"
+    assert data["sellerVKey"] == ""
+    assert data["agentIdentifier"] == "test-agent"
+    assert data["identifierFromPurchaser"] == "purchaser-1"
+    assert "payByTime" in data and "submitResultTime" in data
+
+
+@pytest.mark.asyncio
+async def test_free_agent_start_job_does_not_call_payment_service(mock_config):
+    """With config.free_agent=True, /start_job must not call payment service or start_status_monitoring."""
+    job_executed = []
+
+    free_agent_config = Config(
+        payment_service_url=mock_config.payment_service_url,
+        payment_api_key=mock_config.payment_api_key,
+        free_agent=True,
+    )
+
+    @patch.object(Payment, "create_payment_request", new_callable=AsyncMock)
+    @patch.object(Payment, "start_status_monitoring", new_callable=AsyncMock)
+    async def _run(create_mock, monitor_mock):
+        async def start_job_handler(identifier: str, input_data: dict):
+            job_executed.append((identifier, input_data))
+            return {"result": "done"}
+
+        app = create_masumi_app(
+            config=free_agent_config,
+            agent_identifier="free-agent-test",
+            network="Preprod",
+            start_job_handler=start_job_handler,
+            input_schema_handler={"input_data": [{"id": "text", "type": "string"}]},
+            seller_vkey="test-seller-vkey",
+        )
+        with TestClient(app) as client:
+            resp = client.post(
+                "/start_job",
+                json={
+                    "identifierFromPurchaser": "buyer-1",
+                    "inputData": {"text": "hello"},
+                },
+            )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["blockchainIdentifier"].startswith("FREE-")
+        assert "id" in body
+        create_mock.assert_not_called()
+        monitor_mock.assert_not_called()
+        return body
+
+    body = await _run()
+    assert body["blockchainIdentifier"].startswith("FREE-")
+
+
+@pytest.mark.asyncio
+async def test_free_agent_job_executes_immediately(mock_config):
+    """Free agent returns 200 with FREE- id; job is scheduled off-chain (no payment wait)."""
+    free_agent_config = Config(
+        payment_service_url=mock_config.payment_service_url,
+        payment_api_key=mock_config.payment_api_key,
+        free_agent=True,
+    )
+
+    async def _run():
+        async def start_job_handler(identifier: str, input_data: dict):
+            return {"result": "free-agent-result"}
+
+        app = create_masumi_app(
+            config=free_agent_config,
+            agent_identifier="free-agent-test",
+            network="Preprod",
+            start_job_handler=start_job_handler,
+            input_schema_handler={"input_data": [{"id": "text", "type": "string"}]},
+            seller_vkey="test-seller-vkey",
+        )
+        with TestClient(app) as client:
+            resp = client.post(
+                "/start_job",
+                json={
+                    "identifierFromPurchaser": "buyer-1",
+                    "inputData": {"text": "hello"},
+                },
+            )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["blockchainIdentifier"].startswith("FREE-")
+        assert "id" in data
+        # Free agent path: no payment service, job is scheduled via create_task
+
+    await _run()
 
 
 @pytest.mark.asyncio

--- a/masumi/validation.py
+++ b/masumi/validation.py
@@ -4,6 +4,7 @@ Input schema validation according to MIP-003 Attachment 01.
 
 import re
 import logging
+from datetime import datetime
 from typing import Dict, Any, List, Optional
 from .models import InputField, ValidationRule
 from .helper_functions import setup_logging
@@ -75,6 +76,81 @@ def validate_tel_pattern(value: str) -> bool:
     return bool(re.match(pattern, value))
 
 
+def validate_date_format(value: str) -> bool:
+    """Validate date format (YYYY-MM-DD) with valid month (01-12) and day ranges."""
+    if not isinstance(value, str):
+        return False
+    # HTML date input format: YYYY-MM-DD - use datetime for semantic validation (rejects 2025-13-32, etc.)
+    try:
+        datetime.strptime(value, "%Y-%m-%d")
+        return True
+    except ValueError:
+        return False
+
+
+def validate_datetime_local_format(value: str) -> bool:
+    """Validate datetime-local format (YYYY-MM-DDTHH:MM or YYYY-MM-DDTHH:MM:SS or YYYY-MM-DDTHH:MM:SS.sss) with valid ranges.
+    Per HTML spec, datetime-local must have NO timezone information (strptime rejects +05:00, Z, etc.)."""
+    if not isinstance(value, str):
+        return False
+    # Use strptime (not fromisoformat) to reject timezone offsets - HTML datetime-local is local-only
+    for fmt in ("%Y-%m-%dT%H:%M", "%Y-%m-%dT%H:%M:%S", "%Y-%m-%dT%H:%M:%S.%f"):
+        try:
+            datetime.strptime(value, fmt)
+            return True
+        except ValueError:
+            continue
+    return False
+
+
+def validate_time_format(value: str) -> bool:
+    """Validate time format (HH:MM or HH:MM:SS or HH:MM:SS.sss) with valid ranges (hours 00-23, minutes/seconds 00-59)."""
+    if not isinstance(value, str):
+        return False
+    # Use datetime parsing for semantic validation (rejects 25:00, 12:60, etc.)
+    # All branches use strptime so variable-width components (e.g. "9:5" or "9:5:3.123") are accepted consistently.
+    try:
+        datetime.strptime(value, "%H:%M")
+        return True
+    except ValueError:
+        pass
+    try:
+        datetime.strptime(value, "%H:%M:%S")
+        return True
+    except ValueError:
+        pass
+    try:
+        datetime.strptime(value, "%H:%M:%S.%f")
+        return True
+    except ValueError:
+        pass
+    return False
+
+
+def validate_month_format(value: str) -> bool:
+    """Validate month format (YYYY-MM) with valid month range (01-12)."""
+    if not isinstance(value, str):
+        return False
+    # HTML month input format: YYYY-MM - use strptime for consistency with validate_date_format
+    try:
+        datetime.strptime(value, "%Y-%m")
+        return True
+    except ValueError:
+        return False
+
+
+def validate_week_format(value: str) -> bool:
+    """Validate week format (YYYY-Www) with ISO 8601 week number range (01-53)."""
+    if not isinstance(value, str):
+        return False
+    # HTML week input format: YYYY-Www (e.g., 2025-W01)
+    # ISO 8601 specifies week numbers must be in range 01-53
+    # Note: W53 is accepted for all years. Full ISO 8601 enforcement (W53 only exists in
+    # certain years) would require isocalendar() checks and is not enforced by browsers either.
+    pattern = r'^\d{4}-W(0[1-9]|[1-4][0-9]|5[0-3])$'
+    return bool(re.match(pattern, value))
+
+
 def validate_format(value: Any, format_type: str) -> bool:
     """Validate value format based on format type."""
     format_validators = {
@@ -83,6 +159,11 @@ def validate_format(value: Any, format_type: str) -> bool:
         "nonempty": validate_nonempty,
         "integer": validate_integer,
         "tel-pattern": validate_tel_pattern,
+        "date": validate_date_format,
+        "datetime-local": validate_datetime_local_format,
+        "time": validate_time_format,
+        "month": validate_month_format,
+        "week": validate_week_format,
     }
     
     validator = format_validators.get(format_type)
@@ -313,13 +394,30 @@ def validate_field_value(value: Any, field: InputField) -> List[str]:
         # Display-only field, no validation needed
         pass
     
-    # Auto-validate format for email and url types (per MIP-003 spec)
+    # Auto-validate format for email, url, and date/time types (per MIP-003 spec)
+    # Direct call here (not via validate_format) because type-based validation
+    # is separate from explicit format validation rules in the validations array.
     if field_type == "email" and isinstance(value, str):
         if not validate_email(value):
             errors.append(f"Field '{field_id}' must be a valid email address")
     elif field_type == "url" and isinstance(value, str):
         if not validate_url(value):
             errors.append(f"Field '{field_id}' must be a valid URL")
+    elif field_type == "date" and isinstance(value, str):
+        if not validate_date_format(value):
+            errors.append(f"Field '{field_id}' must be a valid date in YYYY-MM-DD format")
+    elif field_type == "datetime-local" and isinstance(value, str):
+        if not validate_datetime_local_format(value):
+            errors.append(f"Field '{field_id}' must be a valid datetime in YYYY-MM-DDTHH:MM[:SS[.sss]] format")
+    elif field_type == "time" and isinstance(value, str):
+        if not validate_time_format(value):
+            errors.append(f"Field '{field_id}' must be a valid time in HH:MM[:SS[.sss]] format")
+    elif field_type == "month" and isinstance(value, str):
+        if not validate_month_format(value):
+            errors.append(f"Field '{field_id}' must be a valid month in YYYY-MM format")
+    elif field_type == "week" and isinstance(value, str):
+        if not validate_week_format(value):
+            errors.append(f"Field '{field_id}' must be a valid week in YYYY-Www format")
     
     # Process validations array
     if field.validations:


### PR DESCRIPTION
## Summary
- Fixes job failure when an agent is registered as a **free agent** (0 cost) by treating `FundsOrDatumInvalid` as success for free agents and triggering the payment callback.
- Adds MIP-003-style validation for date/time input types: `date`, `datetime-local`, `time`, `month`, and `week`.

## Changes

### Payment (free agent fix)
- **Problem:** For free agents, the payment flow can end in `FundsOrDatumInvalid` instead of `FundS_LOCKED`. The callback was only triggered on `FundsLocked`, so jobs for free agents never completed.
- **Solution:** In the payment monitor, when state is `FundsOrDatumInvalid`, treat it as success only when the payment is for a free agent (inferred from `price`/`amount`/`amounts` being 0). In that case trigger the callback; for paid agents, `FundsOrDatumInvalid` remains an error and the callback is not triggered.
- Docstring for the payment callback updated to describe this behavior.

### Validation (date/time formats)
- New validators: `validate_date_format`, `validate_datetime_local_format`, `validate_time_format`, `validate_month_format`, `validate_week_format` (HTML input / ISO-style formats).
- Wired into `validate_format()` and `validate_field_value()` so `date`, `datetime-local`, `time`, `month`, and `week` fields are validated with clear error messages.

## Testing
- For free agents: register a free agent, trigger a job, and confirm the payment callback runs and the job completes when state is `FundsOrDatumInvalid`.
- For paid agents: confirm that `FundsOrDatumInvalid` still does **not** trigger the callback.
- For validation: submit forms with invalid date/time/month/week values and confirm the new validation errors appear.